### PR TITLE
Fix: remove duplicate "Indian Rupee" key on currency.js

### DIFF
--- a/lib/locales/en/finance/currency.js
+++ b/lib/locales/en/finance/currency.js
@@ -243,10 +243,6 @@ module["exports"] = {
     "code": "ILS",
     "symbol": "₪"
   },
-  "Indian Rupee": {
-    "code": "INR",
-    "symbol": ""
-  },
   "Bhutanese Ngultrum": {
     "code": "BTN",
     "symbol": "Nu"


### PR DESCRIPTION
When building my app using Snowpack I noticed a warning related to a duplicate entry for "Indian Rupee" on `currency,js`. This PR removes the entry that doesn't include the symbol.

Snowpack output is below:

```
[snowpack] ✔ dependencies ready! [21.59s]
[snowpack] ! verifying build...
[snowpack] ✔ verification complete [0.02s]
[snowpack] ! writing build to disk...
[snowpack] ! optimizing build...
 > _snowpack/pkg/faker.js: warning: Duplicate key "Indian Rupee" in object literal
    42255 │   "Indian Rupee": {
          ╵   ~~~~~~~~~~~~~~
   _snowpack/pkg/faker.js: note: The original "Indian Rupee" is here
    42247 │   "Indian Rupee": {
          ╵   ~~~~~~~~~~~~~~

1 warning
[
  {
    detail: undefined,
    location: {
      column: 2,
      file: '_snowpack/pkg/faker.js',
      length: 14,
      line: 42255,
      lineText: '  "Indian Rupee": {'
    },
    text: 'Duplicate key "Indian Rupee" in object literal'
  },
]
```